### PR TITLE
Create a debugging guide using ephemeral containers

### DIFF
--- a/debug/Dockerfile
+++ b/debug/Dockerfile
@@ -1,0 +1,27 @@
+FROM debian
+
+# Install a number of debug utilities
+RUN apt update && apt upgrade
+RUN apt install -y procps gdb gdbserver strace ltrace net-tools lsof dnsutils iputils-ping \
+    host nmap traceroute tcpdump iproute2 netcat-openbsd \
+    socat curl wget less jq gpg ca-certificates \
+    postgresql-client-15 \
+    man manpages man-db manpages-dev
+
+# Install kubectl, per instructions at
+# https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management
+RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+RUN apt update
+RUN apt install -y kubectl
+
+# Install go
+COPY --from=golang:1.21.3 /usr/local/go/ /usr/local/go/
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+# Install delve
+RUN CGO_ENABLED=0 go install -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv@v1.20.2
+ENV PATH="/root/go/bin/:${PATH}}"
+
+# Cool hack to access the root filesystem of the main container
+RUN ln -s /proc/1/root /container

--- a/debug/README.md
+++ b/debug/README.md
@@ -1,0 +1,123 @@
+# Debugging in Kubernetes
+
+This directory provides detailed instructions on debugging a running process within a Kubernetes
+Pod. The steps outlined will guide you through the process of constructing a debug pod, injecting it
+as an ephemeral container into the target pod, and subsequently initiating a Go debugging session
+using Delve. You can use this knowledge to debug your KServe Inference Services, or the any KServe
+component you need, such as the KServe or Knative controllers.
+
+# What You'll Need
+
+To complete this guide, you'll need a working Docker installation, a kind cluster, and `kubectl`.
+You can follow the [KServe in kind](../README.md) guide to set up the kind cluster.
+
+# Procedure
+
+Follow the steps below to start your debugging session:
+
+1. Build your debug container image:
+
+   ```shell
+   docker build -t debian:debug .
+   ```
+
+1. Push the pod on kind:
+
+   ```shell
+   kind load docker-image debian:debug
+   ```
+
+1. Build the client and server images you'll be using a debug targets:
+
+    ```shell
+    docker build -t client:distroless -f client/Dockerfile client/
+    docker build -t server:distroless -f server/Dockerfile server/
+    ```
+
+1. Push the client and server images on kind:
+
+    ```shell
+    kind load docker-image client:distroless
+    kind load docker-image server:distroless
+    ```
+
+1. Inject the debug container into the target pod. To run a live debugging session in a pod, your
+   ephemeral container should have the `SYS_PTRACE` capability and run as root. Unfortunately, you
+   cannot set this through the `kubectl debug` tool yet. Instead, you need to inject this by sending
+   a POST request directly to the API server:
+
+    a. Start a proxy server using `kubectl` to access the API server:
+
+        ```shell
+        kubectl proxy &
+        ```
+    
+    c. Create a POST request to inject the ephemeral container:
+
+        ```shell
+        curl localhost:8001/api/v1/namespaces/default/pods/client/ephemeralcontainers \
+        -XPATCH -H 'Content-Type: application/strategic-merge-patch+json' \
+        -d '
+        {
+            "spec":
+            {
+                "ephemeralContainers":
+                [
+                    {
+                        "name": "debugger",
+                        "command": ["/bin/bash"],
+                        "image": "debian:debug",
+                        "targetContainerName": "server",
+                        "stdin": true,
+                        "tty": true,
+                        "securityContext": {
+                            "capabilities": {
+                                "add": ["SYS_PTRACE"]
+                            },
+                            "runAsNonRoot": false,
+                            "runAsUser": 0,
+                            "runAsGroup": 0
+                        }
+                    }
+                ]
+            }
+        }'
+        ```
+
+    d. Repeat the process for the server pod.
+
+1. Start the Delve debug server and attach on PID `1`:
+
+    ```shell
+    kubectl exec client --container=debugger -- \
+    dlv --headless --accept-multiclient --api-version=2 \
+        --listen  127.0.0.1:1111 \
+        --continue  --log  --log-dest=dlv.log  \
+        attach 1
+    ```
+
+    > Repeat the process for the server Pod but note to change the port that the server is listening
+    > to. The debuging configuration uses `1112` by default.
+
+1. Set up port forwarding to reach the two debugging servers running on the two Pods:
+
+    ```shell
+    kubectl port-forward po/client 1111:1111 &
+    kubectl port-forward po/server 1112:1112 &
+    ```
+
+1. Navigate to VS Code's debugging UI and start a new debugging session. You can use the
+   configuration provided under the `vscode` directory as a starting point. Set your breakpoints and
+   start debugging:
+
+    ```
+    kubectl port-forward po/client 6000:6000 &
+    curl localhost:6000
+    ```
+
+# Conclusion
+
+You've successfully set up a debugging session for a running process in Kubernetes. You can use this
+knowledge to debug your KServe Inference Services, or the any KServe component you need. Moreover,
+the debug container you built includes a number of useful tools that you can use to debug your Pods
+in a live environment, even if they do not have a shell.

--- a/debug/client/Dockerfile
+++ b/debug/client/Dockerfile
@@ -1,0 +1,23 @@
+# Stage 1: Build the Go binary.
+FROM golang:1.21.1 as builder
+
+# Set the Current Working Directory inside the container
+WORKDIR /app
+
+# Copy the source from the current directory to the Working Directory inside the container
+COPY src/ src/
+
+# Set the Current Working Directory inside the container
+WORKDIR /app/src
+
+# Build the Go app
+RUN CGO_ENABLED=0 go build client.go
+
+# Stage 2: Use a distroless base image.
+FROM scratch
+
+# Copy the Pre-built binary file from the previous stage
+COPY --from=builder /app/src/client .
+
+# Command to run the executable
+CMD ["./client"]

--- a/debug/client/client-pod.yaml.j2
+++ b/debug/client/client-pod.yaml.j2
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: client
+  labels:
+    app: client
+spec:
+  containers:
+  - name: client
+    image: {{ CLIENT_IMAGE_NAME }}
+    imagePullPolicy: Always

--- a/debug/client/src/client.go
+++ b/debug/client/src/client.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+func main() {
+	// Handler function for the '/' route
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// Only respond to GET requests
+		if r.Method == http.MethodGet {
+			// Call the upstream server
+			resp, err := http.Get("http://server-service.default.svc.cluster.local:5000")
+			if err != nil {
+				// Handle error.
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			defer resp.Body.Close()
+
+			// Read the response body
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				// Handle error.
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			// Write the response body to the response writer
+			w.WriteHeader(http.StatusOK)
+			w.Write(body)
+		} else {
+			// If the request method is not GET, return a 405 Method Not Allowed
+			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		}
+	})
+
+	// Log that the server is starting
+	fmt.Println("Server is listening on port 6000...")
+
+	// Listen on port 6000
+	if err := http.ListenAndServe(":6000", nil); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/debug/server/Dockerfile
+++ b/debug/server/Dockerfile
@@ -1,0 +1,23 @@
+# Stage 1: Build the Go binary.
+FROM golang:1.21.1 as builder
+
+# Set the Current Working Directory inside the container
+WORKDIR /app
+
+# Copy the source from the current directory to the Working Directory inside the container
+COPY src/ src/
+
+# Set the Current Working Directory inside the container
+WORKDIR /app/src
+
+# Build the Go app
+RUN CGO_ENABLED=0 go build server.go
+
+# Stage 2: Use a distroless base image.
+FROM scratch
+
+# Copy the Pre-built binary file from the previous stage
+COPY --from=builder /app/src/server .
+
+# Command to run the executable
+CMD ["./server"]

--- a/debug/server/server-pod.yaml.j2
+++ b/debug/server/server-pod.yaml.j2
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: server
+  labels:
+    app: server
+spec:
+  containers:
+  - name: server
+    image: {{ SERVER_IMAGE_NAME }}
+    imagePullPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: server-service
+spec:
+  selector:
+    app: server
+  ports:
+    - protocol: TCP
+      port: 5000
+      targetPort: 5000
+  type: ClusterIP

--- a/debug/server/src/server.go
+++ b/debug/server/src/server.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Hello, you've reached the server!")
+	})
+
+	fmt.Println("Server is listening on port 5000...")
+	if err := http.ListenAndServe(":5000", nil); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
Create detailed instructions on debugging a running process within a Kubernetes Pod. This is important to debug a running KServe Inference Service, or the any KServe component, such as the KServe or Knative controllers.